### PR TITLE
Update with new Structured Contents field and renamed infoboxes field

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,36 +6,37 @@ See our [api documentation](https://enterprise.wikimedia.com/docs/) and [website
 
 ## Getting started
 
-- installing the SDK:
+- Install the SDK:
 
 ```bash
-git clone https://github.com/wikimedia-enterprise/wme-sdk-python.git
-cd wme-sdk-python
+$ git clone https://github.com/wikimedia-enterprise/wme-sdk-python.git
+$ cd wme-sdk-python
 
-#edit the `sample.env` file with your credentials and save it as `.env`.  Don't give you WME credentials to anyone!  By the end of this step, you'll have a .env file that looks like, with your username and password:
-#WME_USERNAME=username
-#WME_PASSWORD=password
-#PYTHONPATH=.
+# Edit the `sample.env` file with your credentials and save it as `.env`. Don't give your WME credentials to anyone!
+# By the end of this step, you'll have a .env file that looks like, with your username and password:
+#   WME_USERNAME=username
+#   WME_PASSWORD=password
+#   PYTHONPATH=.
 
 
-#setup the virtual environment
-python3 -m venv sdk
-source sdk/bin/activate
+# Set up the virtual environment
+$ python3 -m venv sdk
+$ . sdk/bin/activate
 
-#install the dependencies
-pip install -r requirements.txt
+# Install the dependencies
+$ pip install -r requirements.txt
 
 # Run the on-demand example
-python3 -m example.ondemand.ondemand
+$ python3 -m example.ondemand.ondemand
 
 # Run the structured contents example
-python3 -m example.structured-contents.structuredcontents
+$ python3 -m example.structured-contents.structuredcontents
 
-#exit the virtual environment
-deactivate
+# Exit the virtual environment
+$ deactivate
 ```
 
-- Expose your credentials (if you don't have credentials already, [sign up](https://dashboard.enterprise.wikimedia.com/signup/)) without a `.env` file:
+- Expose your credentials (if you don't have credentials yet, [sign up](https://dashboard.enterprise.wikimedia.com/signup/)) without a `.env` file:
 
 ```bash
 export WME_USERNAME="...your username...";
@@ -43,7 +44,7 @@ export WME_PASSWORD="...your password...";
 export PYTHONPATH=.
 ```
 
-- obtain your access token:
+- Obtain your access token:
 
 ```python
 import time

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wikimedia Enterprise SDK: Python
 
-Official Wikimedia Enterprise SDK for the Python programming language.
+Draft Wikimedia Enterprise SDK for the Python programming language. This SDK is supposed to serve as an example Python SDK for Wikimedia Enterprise APIs. The SDK is not fully working yet.
 
 See our [api documentation](https://enterprise.wikimedia.com/docs/) and [website](https://enterprise.wikimedia.com/) for more information about the APIs.
 

--- a/example/demo/elections/README.md
+++ b/example/demo/elections/README.md
@@ -1,23 +1,25 @@
 ## Demo of WME Structured Contents API
 
-US Presidential Electorial College Votes over Time from 1980 to 2020.  We take a Data Science approach to collecting the data, tidying the data they way we need it, and then charting it
+US Presidential Electoral College Votes over Time from 1980 to 2020. We take a Data Science approach to collecting the data, tidying the data the way we need it, and then charting it.
 
 Final chart of running the code in this repository:
-![US Presidential Electorial College Votes over Time from 1980 to 2020](image.png)
+![US Presidential Electoral College Votes over Time from 1980 to 2020](image.png)
 
 You must have Python installed.
 
 ## Run Get - Parse - Chart Scripts
 
-Terminal commands, from the project root folder:
+Terminal commands, from the project root folder (`example/demo`):
+
 ```
 # Run the on-demand example
-python -m elections.get
-python -m elections.parse
-python -m elections.chart
+$ python3 -m elections.get
+$ python3 -m elections.parse
+$ python3 -m elections.chart
 ```
+
 To close the chart click the close button on the Window, or on the keyboard press Ctrl-C to stop the command in the terminal.
 
-Example if we set it to start on 1792 to 2020, we adjust the year and nominees names, to make it fit nicely
+Example if we set it to start on 1792 to 2020, we adjust the year and nominees names, to make it fit nicely:
 
 ![alt text](image-1.png)

--- a/example/demo/elections/parse.py
+++ b/example/demo/elections/parse.py
@@ -14,13 +14,13 @@ def remove_prefix(value, prefix):
 # Function to extract needed fields from JSON
 def extract_json_data(json_data):
     # Extracting infobox.has_parts.name (4-digit year)
-    infobox = json_data.get('infobox', [])
+    infoboxes = json_data.get('infoboxes', [])
     year = None
     electoral_vote = None
     running_mate = None
     nominee = None
 
-    for section in infobox:
+    for section in infoboxes:
         if 'has_parts' in section:
             for part in section['has_parts']:
                 # Extract year from name

--- a/example/demo/locations/app.py
+++ b/example/demo/locations/app.py
@@ -84,7 +84,7 @@ async def get_infobox(title: str):
         "Content-Type": "application/json",
     }
     data = {
-        "fields": ["name", "url", "infobox"],
+        "fields": ["name", "url", "infoboxes"],
         "filters": [{"field": "is_part_of.identifier", "value": "enwiki"}],
     }
 

--- a/example/demo/locations/static/map.js
+++ b/example/demo/locations/static/map.js
@@ -33,8 +33,8 @@ function fetchInfobox(title) {
 
         article = data[0]
         info = null
-        if (article.infobox) {
-            info = article.infobox[0]
+        if (article.infoboxes) {
+            info = article.infoboxes[0]
         }
 
         renderInfobox(article.name, article.url, info);

--- a/example/ondemand/ondemand.py
+++ b/example/ondemand/ondemand.py
@@ -53,6 +53,12 @@ def main():
 
         for article in articles:
             try:
+                if "article_body" in article and "html" in article["article_body"]:
+                    html = article["article_body"]["html"]
+                    trunc_marker = "... (truncated)"
+                    max_len = 200
+                    if len(html) > max_len:
+                      article["article_body"]["html"] = html[:max_len - len(trunc_marker)] + trunc_marker
                 art_json = json.dumps(article, indent=2)
                 print(art_json)
             except Exception as e:

--- a/example/structured-contents/structuredcontents.py
+++ b/example/structured-contents/structuredcontents.py
@@ -36,7 +36,7 @@ def main():
 
         request = Request(
             fields=["name", "abstract", "description"],
-            filters=[Filter(field="in_language.identifier", value="en")]
+            filters=[Filter(field="is_part_of.identifier", value="enwiki")]
         )
 
         try:

--- a/modules/api/structuredcontent.py
+++ b/modules/api/structuredcontent.py
@@ -1,12 +1,10 @@
-from typing import List, Optional
+from typing import List, Optional, Dict
 from datetime import datetime
 from modules.api.article import Image
 from version import Version
 from entity import Entity
 from project import Project
 from language import Language
-from namespace import Namespace
-from size import Size
 
 
 class Link:
@@ -26,6 +24,38 @@ class Link:
             images=[Image.from_json(image) for image in data['images']]
         )
 
+    @staticmethod
+    def to_json(link: 'Link') -> dict:
+        return {
+            'url': link.url,
+            'text': link.text,
+            'images': [Image.to_json(image) for image in link.images]
+        }
+
+class Citation:
+    def __init__(self,
+                 identifier: Optional[str] = None,
+                 group: Optional[str] = None,
+                 text: Optional[str] = None):
+        self.identifier = identifier
+        self.group = group
+        self.text = text
+
+    @staticmethod
+    def from_json(data: dict) -> 'Citation':
+        return Citation(
+            identifier=data.get('identifier', ""),
+            group=data.get('group', ""),
+            text=data.get('text', "")
+        )
+
+    @staticmethod
+    def to_json(citation: 'Citation') -> dict:
+        return {
+            'identifier': citation.identifier,
+            'group': citation.group,
+            'text': citation.text
+        }
 
 class Part:
     def __init__(self,
@@ -35,7 +65,8 @@ class Part:
                  values: Optional[List[str]] = None,
                  images: Optional[List[Image]] = None,
                  links: Optional[List[Link]] = None,
-                 has_parts: Optional[List['Part']] = None):
+                 has_parts: Optional[List['Part']] = None,
+                 citations: Optional[List[Citation]] = None):
         self.name = name
         self.part_type = part_type
         self.value = value
@@ -43,6 +74,7 @@ class Part:
         self.images = images or []
         self.links = links or []
         self.has_parts = has_parts or []
+        self.citations = citations or []
 
     @staticmethod
     def from_json(data: dict) -> 'Part':
@@ -53,8 +85,81 @@ class Part:
             values=data['values'],
             images=[Image.from_json(image) for image in data['images']],
             links=[Link.from_json(link) for link in data['links']],
-            has_parts=[Part.from_json(part) for part in data['hasParts']]
+            has_parts=[Part.from_json(part) for part in data['hasParts']],
+            citations=[Citation.from_json(citation) for citation in data['citations']]
         )
+
+    @staticmethod
+    def to_json(part: 'Part') -> dict:
+        return {
+            'name': part.name,
+            'type': part.part_type,
+            'value': part.value,
+            'values': part.values,
+            'images': [Image.to_json(image) for image in part.images],
+            'links': [Link.to_json(link) for link in part.links],
+            'hasParts': [Part.to_json(sub_part) for sub_part in part.has_parts],
+            'citations': [Citation.to_json(citation) for citation in part.citations]
+        }
+
+class ReferenceText:
+    def __init__(self,
+                 value: Optional[str] = None,
+                 links: Optional[List[Link]] = None):
+        self.value = value
+        self.links = links or []
+
+    @staticmethod
+    def from_json(data: dict) -> 'ReferenceText':
+        return ReferenceText(
+            value=data.get('value', ""),
+            links=[Link.from_json(link) for link in data.get('links', [])]
+        )
+
+    @staticmethod
+    def to_json(text: 'ReferenceText') -> dict:
+        return {
+            'value': text.value,
+            'links': [Link.to_json(link) for link in text.links]
+        }
+
+class Reference:
+    def __init__(self,
+                 identifier: Optional[str] = "",
+                 group: Optional[str] = "",
+                 ref_type: Optional[str] = "",
+                 metadata: Optional[Dict[str, str]] = None,
+                 text: Optional[ReferenceText] = None,
+                 source: Optional[ReferenceText] = None):
+        self.identifier = identifier
+        self.group = group
+        self.ref_type = ref_type
+        self.metadata = metadata or {}
+        self.text = text
+        self.source = source
+
+    @staticmethod
+    def from_json(data: dict) -> 'ReferenceText':
+        return ReferenceText(
+            identifier=data.get('identifier', ""),
+            group=data.get('group', ""),
+            ref_type=data.get('type', ""),
+            metadata=data.get('metadata', {}),
+            text=ReferenceText.from_json(data.get('text')),
+            source=ReferenceText.from_json(data.get('source'))
+        )
+
+    @staticmethod
+    def to_json(reference: 'ReferenceText') -> dict:
+        return {
+            'identifier': reference.identifier,
+            'group': reference.group,
+            'type': reference.ref_type,
+            'metadata': reference.metadata,
+            'text': ReferenceText.to_json(reference.text),
+            'source': ReferenceText.to_json(reference.source)
+        }
+
 
 class StructuredContent:
     def __init__(self,
@@ -70,9 +175,10 @@ class StructuredContent:
                  additional_entities: Optional[List[Entity]] = None,
                  is_part_of: Optional[Project] = None,
                  in_language: Optional[Language] = None,
-                 infobox: Optional[List[Part]] = None,
+                 infoboxes: Optional[List[Part]] = None,
                  article_sections: Optional[List[Part]] = None,
-                 image: Optional[Image] = None):
+                 image: Optional[Image] = None,
+                 references: Optional[List[Reference]] = None):
         self.name = name
         self.identifier = identifier
         self.abstract = abstract
@@ -85,9 +191,10 @@ class StructuredContent:
         self.additional_entities = additional_entities or []
         self.is_part_of = is_part_of
         self.in_language = in_language
-        self.infobox = infobox or []
+        self.infoboxes = infoboxes or []
         self.article_sections = article_sections or []
         self.image = image
+        self.references = references or []
 
     @staticmethod
     def from_json(data: dict) -> 'StructuredContent':
@@ -104,9 +211,10 @@ class StructuredContent:
             additional_entities=[Entity.from_json(entity) for entity in data['additionalEntities']],
             is_part_of=Project.from_json(data['isPartOf']),
             in_language=Language.from_json(data['inLanguage']),
-            infobox=[Part.from_json(part) for part in data['infobox']],
+            infoboxes=[Part.from_json(part) for part in data['infoboxes']],
             article_sections=[Part.from_json(section) for section in data['articleSections']],
-            image=Image.from_json(data['image'])
+            image=Image.from_json(data['image']),
+            references=[Reference.from_json(reference) for reference in data.get('references', [])]
         )
 
     @staticmethod
@@ -124,7 +232,8 @@ class StructuredContent:
             'additionalEntities': [Entity.to_json(entity) for entity in structured_content.additional_entities],
             'isPartOf': Project.to_json(structured_content.is_part_of),
             'inLanguage': Language.to_json(structured_content.in_language),
-            'infobox': [Part.to_json(part) for part in structured_content.infobox],
+            'infoboxes': [Part.to_json(part) for part in structured_content.infoboxes],
             'articleSections': [Part.to_json(section) for section in structured_content.article_sections],
-            'image': Image.to_json(structured_content.image)
+            'image': Image.to_json(structured_content.image),
+            'references': [Reference.to_json(reference) for reference in structured_content.references]
         }


### PR DESCRIPTION
- Our API's json output now contains "infoboxes", not "infobox", to make it more consistent with our structured snapshots.
- Add "part.citations" and "references".
- Add missing `Part.to_json` and `Link.to_json`.
- Smaller changes to writing, fix typos, slightly modify examples.