### PR TITLE
Don't parse JSON for each request

### DIFF
--- a/modules/api/api_client.py
+++ b/modules/api/api_client.py
@@ -82,13 +82,6 @@ class Client:
         response = self.http_client.send(prepared)
         response.raise_for_status()
 
-        try:
-            # Attempt to parse the JSON response
-            response.json()
-        except ValueError:
-            print("Failed to revoke token: Invalid or empty JSON response")
-            raise
-
         return response
 
     def _get_entity(self, req: Optional[Request], path: str, val: Any):


### PR DESCRIPTION
Not sure why the JSON always get parsed and the output thrown away. It breaks requests for downloading chunks, these return "binary/octet-stream", and not JSON:

```
downloading enwiktionary_namespace_0_chunk_35 => enwiktionary_namespace_0_chunk_35.tmp
HEAD https://api.enterprise.wikimedia.com/v2/snapshots/enwiktionary_namespace_0/chunks/enwiktionary_namespace_0_chunk_35/download
<Response [200]> 200 binary/octet-stream
Traceback (most recent call last):
  File "/Volumes/Case/wme-sdk-python/venv/lib/python3.12/site-packages/requests/models.py", line 974, in json
    return complexjson.loads(self.text, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/.local/share/mise/installs/python/3.12.3/lib/python3.12/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/.local/share/mise/installs/python/3.12.3/lib/python3.12/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jan/.local/share/mise/installs/python/3.12.3/lib/python3.12/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Volumes/Case/wme-sdk-python/./example/snapshots/snapshots.py", line 94, in <module>
    main()
  File "/Volumes/Case/wme-sdk-python/./example/snapshots/snapshots.py", line 87, in main
    download(api_client, chunk, snapshot_identifier)
  File "/Volumes/Case/wme-sdk-python/./example/snapshots/snapshots.py", line 47, in download
    api_client.download_chunk(snapshot_identifier, chunk, f)
  File "/Volumes/Case/wme-sdk-python/modules/api/api_client.py", line 267, in download_chunk
    self._download_entity(f"snapshots/{sid}/chunks/{idr}/download", writer)
  File "/Volumes/Case/wme-sdk-python/modules/api/api_client.py", line 128, in _download_entity
    headers = self._head_entity(path)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Volumes/Case/wme-sdk-python/modules/api/api_client.py", line 117, in _head_entity
    response = self._do(request)
               ^^^^^^^^^^^^^^^^^
  File "/Volumes/Case/wme-sdk-python/modules/api/api_client.py", line 88, in _do
```